### PR TITLE
fixes errant double quote in Cargo.toml, bumps version in lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "diskonaut"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "crossterm 0.29.0",
  "failure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ description = "Terminal disk space visual navigator"
 version = "0.12.0"
 authors = ["Aram Drevekenin <aram@poor.dev>", "Gregory Shuflin <greg@everydayimshuflin.com>"]
 readme = "README.md"
-homepage = "https://code.everydayimshuflin.com/greg/diskonaut""
-repository = "https://code.everydayimshuflin.com/greg/diskonaut""
+homepage = "https://code.everydayimshuflin.com/greg/diskonaut"
+repository = "https://code.everydayimshuflin.com/greg/diskonaut"
 license = "MIT"
 edition = "2024"
 


### PR DESCRIPTION
Hi, I hit a snag while building. There was a typo in the Cargo.toml file.

I actually didn't bump the version.. I'm assuming the cargo tooling did that, or maybe a git pre-commit hook?  

Also I'm not sure if you're accepting pull requests here - if not, that's fine! I found the git-tea server but didn't immediately see a way to signup.  