### PR TITLE
Port to ratatui 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +77,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,10 +106,24 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags 1.3.2",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width 0.1.14",
  "vec_map",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -176,15 +205,15 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.10.0",
  "crossterm_winapi",
- "libc",
- "mio 0.8.11",
+ "mio",
  "parking_lot",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -200,9 +229,9 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio 1.1.0",
+ "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -215,6 +244,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -248,9 +312,9 @@ dependencies = [
  "insta",
  "jwalk",
  "nix",
+ "ratatui",
  "structopt",
- "tui",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "winapi",
 ]
 
@@ -274,6 +338,12 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -317,10 +387,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -332,12 +425,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -350,6 +464,34 @@ dependencies = [
  "once_cell",
  "similar",
 ]
+
+[[package]]
+name = "instability"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jwalk"
@@ -372,6 +514,12 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -401,6 +549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,18 +570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -490,6 +635,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +683,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.10.0",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +740,19 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -575,9 +760,21 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"
@@ -602,8 +799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 0.8.11",
- "mio 1.1.0",
+ "mio",
  "signal-hook",
 ]
 
@@ -629,10 +825,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structopt"
@@ -651,11 +859,33 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -702,19 +932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags 1.3.2",
- "cassowary",
- "crossterm 0.25.0",
- "unicode-segmentation",
- "unicode-width 0.1.14",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +944,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,9 +962,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -792,20 +1020,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -819,40 +1038,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -862,21 +1060,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -892,21 +1078,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -916,21 +1090,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ license = "MIT"
 edition = "2024"
 
 [dependencies]
-tui = {version="0.19", default-features = false, features = ['crossterm'] }
+ratatui = {version="0.29", default-features = false, features = ['crossterm'] }
 crossterm = "0.29"
 failure = "0.1"
 jwalk = "0.8"
 structopt = "0.3"
 filesize = "0.2.0"
-unicode-width = "0.2.2"
+unicode-width = "0.2"
 nix = { version = "0.30.0", features = ["user"] }
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["securitybaseapi","debugapi"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,8 @@
+use ::ratatui::backend::Backend;
 use ::std::fs::{self, Metadata};
 use ::std::mem::ManuallyDrop;
 use ::std::path::PathBuf;
 use ::std::sync::mpsc::{Receiver, SyncSender};
-use ::tui::backend::Backend;
 
 use crate::Event;
 use crate::messages::{Instruction, handle_instructions};

--- a/src/input/controls.rs
+++ b/src/input/controls.rs
@@ -1,4 +1,4 @@
-use ::tui::backend::Backend;
+use ::ratatui::backend::Backend;
 use crossterm::event::Event;
 use crossterm::event::KeyModifiers;
 use crossterm::event::{KeyCode, KeyEvent, read};

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,10 @@ use ::std::thread::park_timeout;
 use ::std::{thread, time};
 use ::structopt::StructOpt;
 
-use ::tui::backend::Backend;
+use ::ratatui::backend::{Backend, CrosstermBackend};
 use crossterm::event::KeyModifiers;
 use crossterm::event::{Event as BackEvent, KeyCode, KeyEvent};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
-use tui::backend::CrosstermBackend;
 
 use app::{App, UiMode};
 use input::TerminalEvents;

--- a/src/messages/instruction.rs
+++ b/src/messages/instruction.rs
@@ -2,7 +2,7 @@ use ::std::fs::Metadata;
 use ::std::path::PathBuf;
 use ::std::sync::mpsc::Receiver;
 
-use ::tui::backend::Backend;
+use ::ratatui::backend::Backend;
 use crossterm::event::Event as BackEvent;
 
 use crate::input::{

--- a/src/state/tiles/board.rs
+++ b/src/state/tiles/board.rs
@@ -1,4 +1,4 @@
-use ::tui::layout::Rect;
+use ::ratatui::layout::Rect;
 
 use crate::state::files::Folder;
 use crate::state::tiles::files_in_folder::FileType;

--- a/src/state/tiles/rect_float.rs
+++ b/src/state/tiles/rect_float.rs
@@ -1,4 +1,4 @@
-use ::tui::layout::Rect;
+use ::ratatui::layout::Rect;
 
 #[derive(Clone, Debug)]
 pub struct RectFloat {

--- a/src/state/tiles/treemap.rs
+++ b/src/state/tiles/treemap.rs
@@ -1,4 +1,4 @@
-use ::tui::layout::Rect;
+use ::ratatui::layout::Rect;
 
 use crate::state::tiles::{FileMetadata, RectFloat, Tile};
 

--- a/src/tests/fakes/fake_output.rs
+++ b/src/tests/fakes/fake_output.rs
@@ -1,9 +1,9 @@
+use ::ratatui::backend::{Backend, WindowSize};
+use ::ratatui::buffer::Cell;
+use ::ratatui::layout::{Position, Size};
 use ::std::collections::HashMap;
 use ::std::io;
 use ::std::sync::{Arc, Mutex};
-use ::tui::backend::Backend;
-use ::tui::buffer::Cell;
-use ::tui::layout::Rect;
 
 #[derive(Hash, Debug, PartialEq)]
 pub enum TerminalEvent {
@@ -87,7 +87,7 @@ impl Backend for TestBackend {
                     Some(cell) => {
                         // this will contain no style information at all
                         // should be good enough for testing
-                        string.push_str(&cell.symbol);
+                        string.push_str(cell.symbol());
                     }
                     None => {
                         string.push_str(" ");
@@ -100,15 +100,39 @@ impl Backend for TestBackend {
         Ok(())
     }
 
-    fn size(&self) -> io::Result<Rect> {
+    fn size(&self) -> io::Result<Size> {
         let terminal_height = self.terminal_height.lock().unwrap();
         let terminal_width = self.terminal_width.lock().unwrap();
 
-        Ok(Rect::new(0, 0, *terminal_width, *terminal_height))
+        Ok(Size::new(*terminal_width, *terminal_height))
     }
 
     fn flush(&mut self) -> io::Result<()> {
         self.events.lock().unwrap().push(TerminalEvent::Flush);
         Ok(())
+    }
+
+    fn get_cursor_position(&mut self) -> io::Result<Position> {
+        Ok(Position { x: 0, y: 0 })
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, _position: P) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn window_size(&mut self) -> io::Result<WindowSize> {
+        let terminal_width = *self.terminal_width.lock().unwrap();
+        let terminal_height = *self.terminal_height.lock().unwrap();
+        let size = Size {
+            width: terminal_width,
+            height: terminal_height,
+        };
+        Ok(WindowSize {
+            columns_rows: size,
+            pixels: Size {
+                width: 0,
+                height: 0,
+            },
+        })
     }
 }

--- a/src/ui/bottom_line.rs
+++ b/src/ui/bottom_line.rs
@@ -1,8 +1,8 @@
+use ::ratatui::buffer::Buffer;
+use ::ratatui::layout::Rect;
+use ::ratatui::style::{Color, Modifier, Style};
+use ::ratatui::widgets::Widget;
 use ::std::path::PathBuf;
-use ::tui::buffer::Buffer;
-use ::tui::layout::Rect;
-use ::tui::style::{Color, Modifier, Style};
-use ::tui::widgets::Widget;
 
 use crate::state::tiles::{FileType, Tile};
 use crate::ui::format::{DisplaySize, truncate_middle};
@@ -110,7 +110,7 @@ fn render_small_files_legend(buf: &mut Buffer, x: u16, y: u16, small_files_legen
             .bg(Color::Reset)
             .remove_modifier(Modifier::all()),
     );
-    let small_files_legend_character = buf.get_mut(x + 1, y);
+    let small_files_legend_character = &mut buf[(x + 1, y)];
     small_files_legend_character.set_style(Style::default().bg(Color::White).fg(Color::Black));
 }
 

--- a/src/ui/display.rs
+++ b/src/ui/display.rs
@@ -1,7 +1,7 @@
+use ::ratatui::Terminal;
+use ::ratatui::backend::Backend;
+use ::ratatui::layout::{Constraint, Direction, Layout, Size};
 use ::std::path::PathBuf;
-use ::tui::Terminal;
-use ::tui::backend::Backend;
-use ::tui::layout::{Constraint, Direction, Layout, Rect};
 
 use crate::UiMode;
 use crate::state::UiEffects;
@@ -35,7 +35,7 @@ where
         terminal.hide_cursor().expect("failed to hide cursor");
         Display { terminal }
     }
-    pub fn size(&self) -> Rect {
+    pub fn size(&self) -> Size {
         self.terminal.size().expect("could not get terminal size")
     }
     pub fn render(
@@ -47,7 +47,7 @@ where
     ) {
         self.terminal
             .draw(|f| {
-                let full_screen = f.size();
+                let full_screen = f.area();
                 let current_path = file_tree.get_current_path();
                 let current_path_size = file_tree.get_current_folder_size();
                 let current_path_descendants = file_tree.get_current_folder().num_descendants;
@@ -75,12 +75,14 @@ where
                         ]
                         .as_ref(),
                     )
-                    .split(full_screen);
+                    .split(full_screen)
+                    .to_vec();
 
                 // -1 cos we draw starting at offset 1 in both x and y directions
 
                 chunks[1].width -= 1;
                 chunks[1].height -= 1;
+
                 board.change_area(&chunks[1]);
                 match ui_mode {
                     UiMode::Loading => {

--- a/src/ui/grid/draw_next_symbol.rs
+++ b/src/ui/grid/draw_next_symbol.rs
@@ -1,4 +1,4 @@
-use ::tui::buffer::Buffer;
+use ::ratatui::buffer::Buffer;
 
 pub mod boundaries {
     pub const TOP_RIGHT: &str = "┐";
@@ -110,9 +110,9 @@ fn find_next_symbol(first_symbol: &str, second_symbol: &str) -> Option<&'static 
 }
 
 pub fn draw_next_symbol(buf: &mut Buffer, x: u16, y: u16, symbol: &str) {
-    if let Some(next_symbol) = find_next_symbol(&buf.get(x, y).symbol, symbol) {
-        buf.get_mut(x, y).set_symbol(next_symbol);
+    if let Some(next_symbol) = find_next_symbol(buf[(x, y)].symbol(), symbol) {
+        buf[(x, y)].set_symbol(next_symbol);
     } else {
-        buf.get_mut(x, y).set_symbol(symbol);
+        buf[(x, y)].set_symbol(symbol);
     }
 }

--- a/src/ui/grid/draw_rect.rs
+++ b/src/ui/grid/draw_rect.rs
@@ -1,6 +1,6 @@
-use ::tui::buffer::Buffer;
-use ::tui::layout::Rect;
-use ::tui::style::{Color, Modifier, Style};
+use ::ratatui::buffer::Buffer;
+use ::ratatui::layout::Rect;
+use ::ratatui::style::{Color, Modifier, Style};
 use ::unicode_width::UnicodeWidthStr;
 
 use crate::state::tiles::{FileType, Tile};
@@ -125,7 +125,7 @@ pub fn draw_filled_rect(buf: &mut Buffer, fill_style: Style, rect: &Rect) {
     // fill
     for x in rect.x + 1..(rect.x + rect.width) {
         for y in rect.y + 1..(rect.y + rect.height) {
-            let cell = buf.get_mut(x, y);
+            let cell = &mut buf[(x, y)];
             cell.set_symbol(" ");
             cell.set_style(fill_style);
         }
@@ -134,24 +134,24 @@ pub fn draw_filled_rect(buf: &mut Buffer, fill_style: Style, rect: &Rect) {
     // top and bottom
     for x in rect.x..(rect.x + rect.width + 1) {
         if x == rect.x {
-            buf.get_mut(x, rect.y)
+            buf[(x, rect.y)]
                 .set_symbol(&boundaries::TOP_LEFT)
                 .set_style(fill_style);
-            buf.get_mut(x, rect.y + rect.height)
+            buf[(x, rect.y + rect.height)]
                 .set_symbol(&boundaries::BOTTOM_LEFT)
                 .set_style(fill_style);
         } else if x == rect.x + rect.width {
-            buf.get_mut(x, rect.y)
+            buf[(x, rect.y)]
                 .set_symbol(&boundaries::TOP_RIGHT)
                 .set_style(fill_style);
-            buf.get_mut(x, rect.y + rect.height)
+            buf[(x, rect.y + rect.height)]
                 .set_symbol(&boundaries::BOTTOM_RIGHT)
                 .set_style(fill_style);
         } else {
-            buf.get_mut(x, rect.y)
+            buf[(x, rect.y)]
                 .set_symbol(&boundaries::HORIZONTAL)
                 .set_style(fill_style);
-            buf.get_mut(x, rect.y + rect.height)
+            buf[(x, rect.y + rect.height)]
                 .set_symbol(&boundaries::HORIZONTAL)
                 .set_style(fill_style);
         }
@@ -159,10 +159,10 @@ pub fn draw_filled_rect(buf: &mut Buffer, fill_style: Style, rect: &Rect) {
 
     // left and right
     for y in (rect.y + 1)..(rect.y + rect.height) {
-        buf.get_mut(rect.x, y)
+        buf[(rect.x, y)]
             .set_symbol(&boundaries::VERTICAL)
             .set_style(fill_style);
-        buf.get_mut(rect.x + rect.width, y)
+        buf[(rect.x + rect.width, y)]
             .set_symbol(&boundaries::VERTICAL)
             .set_style(fill_style);
     }
@@ -182,9 +182,7 @@ pub fn draw_tile_text_on_grid(buf: &mut Buffer, tile: &Tile, selected: bool) {
     if let Some(background_style) = background_style {
         for x in tile.x + 1..tile.x + tile.width {
             for y in tile.y + 1..tile.y + tile.height {
-                buf.get_mut(x, y)
-                    .set_symbol("█")
-                    .set_style(background_style);
+                buf[(x, y)].set_symbol("█").set_style(background_style);
                 // we set both the filling symbol and the style
                 // because some terminals do not show this symbol on the one side
                 // and our tests need it in order to pass on the other side

--- a/src/ui/grid/rectangle_grid.rs
+++ b/src/ui/grid/rectangle_grid.rs
@@ -1,7 +1,7 @@
-use ::tui::buffer::Buffer;
-use ::tui::layout::Rect;
-use ::tui::style::{Color, Style};
-use ::tui::widgets::Widget;
+use ::ratatui::buffer::Buffer;
+use ::ratatui::layout::Rect;
+use ::ratatui::style::{Color, Style};
+use ::ratatui::widgets::Widget;
 
 use crate::state::tiles::Tile;
 use crate::ui::grid::{draw_rect_on_grid, draw_tile_text_on_grid};
@@ -9,7 +9,7 @@ use crate::ui::grid::{draw_rect_on_grid, draw_tile_text_on_grid};
 fn draw_small_files_rect_on_grid(buf: &mut Buffer, rect: Rect) {
     for x in rect.x + 1..(rect.x + rect.width) {
         for y in rect.y + 1..(rect.y + rect.height) {
-            let buf = buf.get_mut(x, y);
+            let buf = &mut buf[(x, y)];
             buf.set_symbol("x");
             buf.set_style(Style::default().bg(Color::White).fg(Color::Black));
         }
@@ -20,7 +20,7 @@ fn draw_small_files_rect_on_grid(buf: &mut Buffer, rect: Rect) {
 fn draw_empty_folder(buf: &mut Buffer, area: Rect) {
     for x in area.x + 1..area.x + area.width {
         for y in area.y + 1..area.y + area.height {
-            let buf = buf.get_mut(x, y);
+            let buf = &mut buf[(x, y)];
             buf.set_symbol("█");
             buf.set_style(Style::default().bg(Color::White).fg(Color::Black));
         }

--- a/src/ui/modals/confirm_box.rs
+++ b/src/ui/modals/confirm_box.rs
@@ -1,7 +1,7 @@
-use ::tui::buffer::Buffer;
-use ::tui::layout::Rect;
-use ::tui::style::{Color, Modifier, Style};
-use ::tui::widgets::Widget;
+use ::ratatui::buffer::Buffer;
+use ::ratatui::layout::Rect;
+use ::ratatui::style::{Color, Modifier, Style};
+use ::ratatui::widgets::Widget;
 
 use crate::ui::format::truncate_middle;
 use crate::ui::grid::draw_filled_rect;

--- a/src/ui/modals/error_box.rs
+++ b/src/ui/modals/error_box.rs
@@ -1,7 +1,7 @@
-use ::tui::buffer::Buffer;
-use ::tui::layout::Rect;
-use ::tui::style::{Color, Modifier, Style};
-use ::tui::widgets::Widget;
+use ::ratatui::buffer::Buffer;
+use ::ratatui::layout::Rect;
+use ::ratatui::style::{Color, Modifier, Style};
+use ::ratatui::widgets::Widget;
 
 use crate::ui::format::truncate_end;
 use crate::ui::grid::draw_filled_rect;

--- a/src/ui/modals/message_box.rs
+++ b/src/ui/modals/message_box.rs
@@ -1,7 +1,7 @@
-use ::tui::buffer::Buffer;
-use ::tui::layout::Rect;
-use ::tui::style::{Color, Modifier, Style};
-use ::tui::widgets::Widget;
+use ::ratatui::buffer::Buffer;
+use ::ratatui::layout::Rect;
+use ::ratatui::style::{Color, Modifier, Style};
+use ::ratatui::widgets::Widget;
 
 use crate::state::FileToDelete;
 use crate::state::tiles::FileType;

--- a/src/ui/modals/warning_box.rs
+++ b/src/ui/modals/warning_box.rs
@@ -1,7 +1,7 @@
-use tui::buffer::Buffer;
-use tui::layout::Rect;
-use tui::style::{Color, Modifier, Style};
-use tui::widgets::Widget;
+use ::ratatui::buffer::Buffer;
+use ::ratatui::layout::Rect;
+use ::ratatui::style::{Color, Modifier, Style};
+use ::ratatui::widgets::Widget;
 
 use crate::ui::format::truncate_end;
 use crate::ui::grid::draw_filled_rect;

--- a/src/ui/term_too_small.rs
+++ b/src/ui/term_too_small.rs
@@ -1,7 +1,7 @@
-use ::tui::buffer::Buffer;
-use ::tui::layout::Rect;
-use ::tui::style::{Modifier, Style};
-use ::tui::widgets::Widget;
+use ::ratatui::buffer::Buffer;
+use ::ratatui::layout::Rect;
+use ::ratatui::style::{Modifier, Style};
+use ::ratatui::widgets::Widget;
 
 pub struct TermTooSmall {}
 

--- a/src/ui/title/title_line.rs
+++ b/src/ui/title/title_line.rs
@@ -1,8 +1,8 @@
+use ::ratatui::buffer::Buffer;
+use ::ratatui::layout::Rect;
+use ::ratatui::style::{Color, Modifier, Style};
+use ::ratatui::widgets::Widget;
 use ::std::path::PathBuf;
-use ::tui::buffer::Buffer;
-use ::tui::layout::Rect;
-use ::tui::style::{Color, Modifier, Style};
-use ::tui::widgets::Widget;
 
 use crate::ui::FolderInfo;
 use crate::ui::format::DisplaySize;

--- a/src/ui/title/title_telescope.rs
+++ b/src/ui/title/title_telescope.rs
@@ -1,6 +1,6 @@
-use ::tui::buffer::Buffer;
-use ::tui::layout::Rect;
-use ::tui::style::{Color, Modifier, Style};
+use ::ratatui::buffer::Buffer;
+use ::ratatui::layout::Rect;
+use ::ratatui::style::{Color, Modifier, Style};
 
 use ::std::cmp::max;
 
@@ -192,17 +192,15 @@ impl TitleTelescope {
     }
     fn draw_loading_chars(&self, text_length: u16, rect: Rect, buf: &mut Buffer) {
         let index_in_text = (self.loading_indicator as u16 % (text_length)) as u16;
-        buf.get_mut(rect.x + 1 + index_in_text, rect.y)
+        buf[(rect.x + 1 + index_in_text, rect.y)]
             .set_style(Style::default().add_modifier(Modifier::BOLD));
         if index_in_text >= text_length - 2 {
-            buf.get_mut(rect.x + 1, rect.y)
-                .set_style(Style::default().add_modifier(Modifier::BOLD));
-            buf.get_mut(rect.x + 2, rect.y)
-                .set_style(Style::default().add_modifier(Modifier::BOLD));
+            buf[(rect.x + 1, rect.y)].set_style(Style::default().add_modifier(Modifier::BOLD));
+            buf[(rect.x + 2, rect.y)].set_style(Style::default().add_modifier(Modifier::BOLD));
         } else {
-            buf.get_mut(rect.x + 1 + index_in_text + 1, rect.y)
+            buf[(rect.x + 1 + index_in_text + 1, rect.y)]
                 .set_style(Style::default().add_modifier(Modifier::BOLD));
-            buf.get_mut(rect.x + 1 + index_in_text + 2, rect.y)
+            buf[(rect.x + 1 + index_in_text + 2, rect.y)]
                 .set_style(Style::default().add_modifier(Modifier::BOLD));
         }
     }


### PR DESCRIPTION
Hi @neunenak. The last released version of diskonaut depends on quite a few unmaintained crates, which as such should not be packaged in distributions. In order to package an updated version of diskonaut in distros (I intend to do so for Debian, when possible), the following crates should be replaced with maintained alternatives:

tui (repo archived in 2023, forked to ratatui) -> ratatui
failure (repo archived in 2021) -> anyhow or thiserror
jwalk (unmaintained since early 2024) -> ?
structopt (unmaintained since 2023, integrated into clap) -> native clap?
filesize (unmaintained since 2020) -> ?

This PR is one step in that direction. It ports your refresh of diskonaut to ratatui 0.29. Please let me know what you think and thanks for caring about diskonaut!

